### PR TITLE
Overridable help text generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,26 @@ That is what you wanted from the start.
 At the same time, the named option remains, so you can use either version. Bound entries are not removed from the unparsed command line entries.
 
 
+### Help text generation
+
+CLI-matic comes with pre-packaged help text generators for global and sub-command help.
+These generators can be overridden by supplying one or more of your own functions in the `:app` section of the configuration:
+
+
+	(defn my-command-help [setup]
+	  " ... ")
+	
+	(defn gen-sub-command-help [setup subcmd]
+	  " ... ")
+	
+	{:app {:global-help my-command-help
+	       :subcmd-help gen-sub-command-help}}
+
+
+The function specified for `:global-help` accepts the CLI configuration, and `:subcmd-help` additionally accepts the sub-command it was called with.
+Each function returns a string that CLI-matic prints verbatim to the user as the full help text.
+
+
 ### Transitive dependencies
 
 CLI-matic currently depends on:

--- a/src/cli_matic/core.clj
+++ b/src/cli_matic/core.clj
@@ -952,9 +952,9 @@
          ["** ERROR: **" stderr "" ""]))))
     (cond
       (= :HELP-GLOBAL help)
-      (println (asString ((get-in setup :app :global-help) setup)))
+      (println (asString ((get-in setup [:app :global-help]) setup)))
       (= :HELP-SUBCMD help)
-      (println (asString ((get-in setup :app :subcmd-help) setup subcmd))))
+      (println (asString ((get-in setup [:app :subcmd-help]) setup subcmd))))
     (P/exit-script retval)))
 
 (st/instrument)

--- a/src/cli_matic/core.clj
+++ b/src/cli_matic/core.clj
@@ -945,9 +945,9 @@
          ["** ERROR: **" stderr "" ""]))))
     (cond
       (= :HELP-GLOBAL help)
-      (println (asString ((setup :global-help) setup)))
+      (println (asString ((get-in setup :app :global-help) setup)))
       (= :HELP-SUBCMD help)
-      (println (asString ((setup :subcmd-help) setup subcmd))))
+      (println (asString ((get-in setup :app :subcmd-help) setup subcmd))))
     (P/exit-script retval)))
 
 (st/instrument)

--- a/src/cli_matic/core.clj
+++ b/src/cli_matic/core.clj
@@ -830,14 +830,19 @@
                               (str "Option error: " (:error-text parsed-opts)))
       :NONE (invoke-subcmd (:subcommand-def parsed-opts) (:commandline parsed-opts)))))
 
+(def setup-defaults
+  {:global-help generate-global-help
+   :subcmd-help generate-subcmd-help})
+
 (defn run-cmd
   "This is the actual function that is executed.
   It wraps run-cmd* and then does the printing
   of any errors, of help pages and  System.exit.
   As it invokes Sys.exit you cannot use it from a REPL.
   "
-  [args setup]
-  (let [{:keys [help stderr subcmd retval]}
+  [args supplied-setup]
+  (let [setup (merge setup-defaults supplied-setup)
+        {:keys [help stderr subcmd retval]}
         (run-cmd* setup (if (nil? args) [] args))]
     (if (not (empty? stderr))
       (println
@@ -846,9 +851,9 @@
          ["** ERROR: **" stderr "" ""]))))
     (cond
       (= :HELP-GLOBAL help)
-      (println (asString (generate-global-help setup)))
+      (println (asString ((setup :global-help) setup)))
       (= :HELP-SUBCMD help)
-      (println (asString (generate-subcmd-help setup subcmd))))
+      (println (asString ((setup :subcmd-help) setup subcmd))))
     (P/exit-script retval)))
 
 (st/instrument)

--- a/src/cli_matic/core.clj
+++ b/src/cli_matic/core.clj
@@ -934,6 +934,7 @@
   As it invokes Sys.exit you cannot use it from a REPL.
   "
   [args supplied-setup]
+  (println "* THIS IS RUN-CMD *")
   (let [setup (merge setup-defaults supplied-setup)
         {:keys [help stderr subcmd retval]}
         (run-cmd* setup (if (nil? args) [] args))]


### PR DESCRIPTION
Howdy! The newly-added section in the README.md has the details.
This change brings cli-matic closer to par with `urfave/cli` and others..

Notes:
- The roles of `:app :description` and `:app :global-opts` might have changed slightly.
- I felt that `cli-matic/core.clj` could be decomposed into smaller pieces, with at least a new off-shoot for help text generation, perhaps `cli-matic/help.clj`.
- No spec's are added; not sure how you want to approach that.
- Didn't add any tests; `run-cmd` directly `println`s the generated help text.