### PR TITLE
Support true/false keywords: "true" -> :true "false" -> :false

### DIFF
--- a/src/cli_matic/presets.cljc
+++ b/src/cli_matic/presets.cljc
@@ -71,7 +71,11 @@
 
 (defn asKeyword
   [s]
-  (-> s replace-double-colon P/parseEdn keyword))
+  (-> s
+      replace-double-colon
+      P/parseEdn
+      (as-> s (if (boolean? s) (str s) s))
+      keyword))
 
 
 ; =================================================================

--- a/test/cli_matic/presets_test.cljc
+++ b/test/cli_matic/presets_test.cljc
@@ -167,6 +167,30 @@
       {:commandline  {:_arguments []
                       :val        :user/abcd}
        :error-text   ""
+       :parse-errors :NONE}))
+  (testing "true"
+    (are [i o]
+        (= (parse-cmds-simpler
+            i
+            (mkDummyCfg {:option "val" :as "x" :type :keyword})) o)
+
+                                        ;
+      ["foo" "--val" "true"]
+      {:commandline  {:_arguments []
+                      :val        :true}
+       :error-text   ""
+       :parse-errors :NONE}))
+  (testing "false"
+    (are [i o]
+        (= (parse-cmds-simpler
+            i
+            (mkDummyCfg {:option "val" :as "x" :type :keyword})) o)
+
+                                        ;
+      ["foo" "--val" "false"]
+      {:commandline  {:_arguments []
+                      :val        :false}
+       :error-text   ""
        :parse-errors :NONE})))
 
 ; :string


### PR DESCRIPTION
Previously:

```
(cli/parse-cmds ["--opt1" "true" "test"]
                {:global-opts [{:option "opt1" 
                                :short  "o"
                                :type   :keyword}]
                 :commands    [{:command "test"}]})
=>
{:subcommand "test",
 :subcommand-def {:command "test"},
 :commandline {:opt1 nil, :_arguments []},
 :parse-errors :NONE,
 :error-text ""}
```