### PR TITLE
Allow multiline values for :as in options via customized :summary-fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. This change
 * Fixes #88 - Tests now pass in a timezone-independent way (tks lread)
 * Fixes #86 - Upgrade to Expound 0.8.0
 * Fixes #90 - Positional arguments USAGE help is not formatted correctly (tks lread)
+* Fixes #94 - Add support for multiline help for option :as key in cli-matic config (tks lread)
 
 ## 0.3.11 - 2019-11-24
 ### Changes

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ It contains:
 * Information on the app itself (name, version)
 * The list of global parameters, i.e. the ones that apply to al subcommands (may be empty, or you may skip it at all)
 * A list of sub-commands, each with its own parameters in `:opts`, and a function to be called in `:runs`. You can optionally validate the full parameter-map that is received by subcommand at once by passing a Spec into `:spec`.
+* Help under `:description` and `:as` keys - use a vector of strings for multiline help.
 * If within the subcommand you add a 0-arity function to `:on-shutdown`, it will be called when the JVM terminates. This is
   mostly useful for long running servers, or to do some clean-up. Note that the hook is always called - whether the shutdown 
   is forced by pressing (say) Ctrl+C or just by the JVM exiting. See the examples. 

--- a/src/cli_matic/help_gen.cljc
+++ b/src/cli_matic/help_gen.cljc
@@ -6,11 +6,9 @@
 
 
   "
-  (:require [clojure.tools.cli :as cli]
-            [clojure.spec.alpha :as s]
+  (:require [clojure.spec.alpha :as s]
             [clojure.string :as str]
             [cli-matic.specs :as S]
-          ;  [cli-matic.platform :as P]
             [cli-matic.utils :as U]
             [cli-matic.utils-candidates :as UB]
             [cli-matic.optionals :as OPT]))
@@ -43,15 +41,10 @@
      (generate-section opts-title opts)])))
 
 (defn get-options-summary
-  "To get the summary of options, we pass options to
-  tools.cli parse-opts and an empty set of arguments.
-  Parsing will fail but we get the :summary.
-  We then split it into a collection of lines."
+  "Returns a collection of option summary lines
+  for `cfg` and `subcmd`."
   [cfg subcmd]
-  (let [cli-cfg (U/rewrite-opts cfg subcmd)
-        options-str (:summary
-                     (cli/parse-opts [] cli-cfg))]
-    (str/split-lines options-str)))
+  (U/get-options-summary cfg subcmd))
 
 (defn get-first-rest-description-rows
   "get title and description of description rows"

--- a/test/cli_matic/help_gen_test.cljc
+++ b/test/cli_matic/help_gen_test.cljc
@@ -168,3 +168,104 @@
        "   -?, --help"
        ""]
       (generate-subcmd-help CONFIGURATION-POSITIONAL-TOYCALC "add"))))
+
+(def CONFIGURATION-MULTILINES
+  {:app         {:command     "multiline"
+                 :description ["An app description can span"
+                               "multiple lines."]
+                 :version     "1.2.3"}
+   :global-opts [{:option  "global-opt"
+                  :as      ["Global opt help"
+                            "with"
+                            "multiple lines."]
+                  :type    :int
+                  :default 10}]
+   :commands    [{:command     "mycmd"
+                  :description ["A command description"
+                                ""
+                                "Can contain multiple lines."
+                                "Only the first line is displayed on global help."]
+                  :opts        [{:option "mycmd-opt1" :short "a" :type :int :default 0
+                                 :as ["not really a multiline but just fine"]}
+                                {:option "long-name-here-should-stretch-things-out" :short "l" :type :keyword
+                                 :as ["testing out how a longer"
+                                      "option affects things."]}
+                                {:option "opt2"                  :type :int :default 0
+                                 :as ["text that is long"
+                                      "can be split"
+                                      "over"
+                                      "many"
+                                      "lines"
+                                      "and"
+                                      " will"
+                                      "  be"
+                                      "   indented"
+                                      "    appropriately"
+                                      "and"
+                                      "can"
+                                      "include empty"
+                                      ""
+                                      "lines."]}
+                                {:option "opt3" :short "c" :env "ENV_VAR" :type :string :multiple true :default :present
+                                 :as ["here's what happens to a multiline with"
+                                      "env also set"]}]
+                  :runs        dummy-cmd}]})
+
+(deftest multilines-global-help-test
+  (is
+   (= ["NAME:"
+       " multiline - An app description can span"
+       " multiple lines."
+       ""
+       "USAGE:"
+       " multiline [global-options] command [command options] [arguments...]"
+       ""
+       "VERSION:"
+       " 1.2.3"
+       ""
+       "COMMANDS:"
+       "   mycmd                A command description"
+       ""
+       "GLOBAL OPTIONS:"
+       "       --global-opt N  10  Global opt help"
+       "                           with"
+       "                           multiple lines."
+       "   -?, --help"
+       ""]
+      (generate-global-help CONFIGURATION-MULTILINES))))
+
+(deftest multilines-cmd-help-test
+  (is
+   (= ["NAME:"
+       " multiline mycmd - A command description"
+       " "
+       " Can contain multiple lines."
+       " Only the first line is displayed on global help."
+       ""
+       "USAGE:"
+       " multiline mycmd [command options] [arguments...]"
+       ""
+       "OPTIONS:"
+       "   -a, --mycmd-opt1 N                                0  not really a multiline but just fine"
+       "   -l, --long-name-here-should-stretch-things-out S     testing out how a longer"
+       "                                                        option affects things."
+       "       --opt2 N                                      0  text that is long"
+       "                                                        can be split"
+       "                                                        over"
+       "                                                        many"
+       "                                                        lines"
+       "                                                        and"
+       "                                                         will"
+       "                                                          be"
+       "                                                           indented"
+       "                                                            appropriately"
+       "                                                        and"
+       "                                                        can"
+       "                                                        include empty"
+       " "
+       "                                                        lines."
+       "   -c, --opt3 S*                                        here's what happens to a multiline with"
+       "                                                        env also set [$ENV_VAR]"
+       "   -?, --help"
+       ""]
+      (generate-subcmd-help CONFIGURATION-MULTILINES "mycmd"))))


### PR DESCRIPTION
The value for :as acts as an option's description. Like the :app and :command
:description, :as now optionally supports multiline text via a vector of
strings.

Notes:
Cli-matic takes advantage of clojure.tools.cli to format options for display
in help. Ideally clojure.tools.cli would accept multiline descriptions for
options, but it does not.

We take advantage of clojure.tools.cli's :summary-fn to override default
handling and support multilines.

This work includes the strengthening of the spec for descriptions. A description
must be a non-blank string - or - a collection of strings that includes at least
one non-blank string.

I also moved the beef of get-clojure-options under utils to localize
interactions with clojure.tools.cli

Fixes #94