### PR TITLE
Remove core.async from deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,6 @@
  org.clojure/clojure {:mvn/version "1.9.0"}
  org.clojure/spec.alpha {:mvn/version "0.1.143"}
  org.clojure/tools.cli {:mvn/version "0.3.7"}
- org.clojure/core.async {:mvn/version "0.5.527"}
  expound {:mvn/version "0.7.1"}
  }}
 


### PR DESCRIPTION
I was working on compiling my project to a native executable using
GraalVM and I was having some trouble — it was requiring a LOT of memory
and a LOT of time. (For example I was having trouble building my tool
with native-image on GitHub Actions, as the runners provided by GitHub
are limited to 7GB of RAM.)

So I decided to look at my project’s dependency tree, and I noticed that
cli-matic seemed to have a rather subtree. core.async caught my eye
immediately; it wasn’t immediately obvious why cli-matic would need
core.async.

So I poked around in the cli-matic repo to try to see what core.async
was used for, and I found `optionals.clj`. The docstring in the ns form
doesn’t like core.async, but there’s
[a section](https://github.com/l3nz/cli-matic/blob/b402e7d073eaf6c0e628e61c23b9fd935df7c8cc/src/cli_matic/optionals.clj#L90)
at the bottom that’s about core.async.

So it seemed to me that core async was *supposed* to be optional. My
next question was: if it was optional, why was it being included in my
project. First I checked out `deps.edn` because my project uses
tools.deps, and saw, unsurprisingly, that core.async was right
[in there](https://github.com/l3nz/cli-matic/blob/b402e7d073eaf6c0e628e61c23b9fd935df7c8cc/deps.edn#L5).

Next I checked [`project.clj`](https://github.com/l3nz/cli-matic/blob/b402e7d073eaf6c0e628e61c23b9fd935df7c8cc/project.clj#L24)
and saw this:

```clojure
[org.clojure/core.async "0.5.527" :scope "provided"]
```

seeing that `:scope "provided"` led me to hypothesize that when the
file `deps.edn` was created, core.async was transferred into it
inadvertently, given that `deps.edn` has no equivalent to Maven’s
`provided` scope.

So it seems to me that `core.async` should probably be removed from
`deps.edn` so that, for projects that use tools.deps, `core.async` would
be *actually* optional.

So I tried it, and the results seemed positive. With core.async and
*its* dependencies removed from my project, I was suddenly able to build
my project on GitHub Actions with 6GB of RAM allocated to GraalVM, and
my build times on my machine dropped significantly.

This change seems to me to be a good thing — given that cli-matic is all
about creating CLI programs with Clojure, and that such programs have
a significantly better UX when compiled with GraalVM’s native-image
tool, this change seems like a no-brainer to me.