### PR TITLE
Make library compatible with babashka.

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -1,6 +1,6 @@
 name: Clojure CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -13,3 +13,18 @@ jobs:
       run: lein deps
     - name: Run tests
       run: lein test
+
+  babashka-tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Setup Babashka
+      uses: turtlequeue/setup-babashka@v1.3.0
+      with:
+        babashka-version: 0.7.5
+
+    - name: Babashka tests
+      run: bb test

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Or the library can be easily referenced through Github when using `deps` (make s
 * **Validate with Spec.** Modern Clojure uses Spec, so validation should be spec-based as well. Validation should happen at the parameter level, and across all parameters of the subcommand at once, and emit sane error messages. Again, the more you have in declarative code, the less room for mistakes.  
 * **Read environment variables.** Passing environment variables is a handy way to inject passwords, etc. This should just happen and be declarative.
 * **Capture unnamed parameters** as if they were named parameters, with casting, validation, etc.
+* **Babashka-compatible**. Read [here](#babashka) for more info.
 
 While targeted at scripting, CLI-matic of course works with any program receiving CLI arguments.
 
@@ -264,6 +265,13 @@ Both functions receive the the configuration and the sub-command it was called w
 
 See example in `helpgen.clj`.
 
+## Babashka
+
+This library is compatible with babashka. In addition to this library, you need
+to include babashka's [fork of
+clojure.spec.alpha](https://github.com/babashka/spec.alpha) in your
+`bb.edn`. Also see this project's `bb.edn` for how thid project's tests are run
+with babashka.
 
 ## Old (non-recursive) configuration
 

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,14 @@
+{:paths ["src" "test"]
+ :deps {org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
+                                 :sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}
+        project/deps {:local/root "."}}
+ :tasks {test {:extra-deps {io.github.cognitect-labs/test-runner
+                            {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
+                            org.clojure/tools.namespace {:git/url "https://github.com/babashka/tools.namespace"
+                                                         :git/sha "3625153ee66dfcec2ba600851b5b2cbdab8fae6c"}
+                            cljc.java-time {:mvn/version "0.1.11"}}
+               :requires ([cognitect.test-runner :as tr])
+               :task (apply tr/-main
+                            "-d" "test"
+                            "-e" "skip-bb"
+                            *command-line-args*)}}}

--- a/deps.edn
+++ b/deps.edn
@@ -3,6 +3,5 @@
  org.clojure/spec.alpha {:mvn/version "0.1.143"}
  org.clojure/tools.cli {:mvn/version "0.3.7"}
  org.clojure/core.async {:mvn/version "0.5.527"}
- expound {:mvn/version "0.7.1"}
- }}
+ expound {:mvn/version "0.7.1"}}}
 

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
    [org.clojure/tools.cli "1.0.194"]
    [orchestra "2019.02.06-1" :scope "provided"]
    [cheshire "5.10.0" :scope "provided"]
-   [io.forward/yaml "1.0.9" :scope "provided"]
+   [io.forward/yaml "1.0.11" :scope "provided"]
    [org.clojure/core.async "0.5.527" :scope "provided"]
    ;[planck "2.22.0" :scope "provided"]
    [l3nz/planck "0.0.0" :scope "provided"]

--- a/src/cli_matic/optionals.clj
+++ b/src/cli_matic/optionals.clj
@@ -91,7 +91,7 @@
 
 (def with-core-async?
   (try
-    (require 'clojure.core.async)
+    (require 'clojure.core.async.impl.channels)
     true
     (catch Throwable _ false)))
 

--- a/src/cli_matic/platform.clj
+++ b/src/cli_matic/platform.clj
@@ -11,8 +11,7 @@
   "
   (:require [clojure.edn :as edn]
             [cli-matic.optionals :as OPT])
-  (:import (clojure.lang IPending)
-           (java.text SimpleDateFormat)))
+  (:import (clojure.lang IPending)))
 
 (defn read-env
   "Reads an environment variable.
@@ -58,14 +57,17 @@
   [s]
   (Float/parseFloat s))
 
+(def ^:private formatter
+  (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd"))
+
 (defn asDate
   "Converts a string in format yyyy-mm-dd to a
   Date object; if conversion
   fails, returns nil."
   [s]
   (try
-    (.parse
-     (SimpleDateFormat. "yyyy-MM-dd") s)
+    (java.sql.Date/valueOf
+     (java.time.LocalDate/parse s formatter))
     (catch Throwable _
       nil)))
 

--- a/test/cli_matic/presets_test.cljc
+++ b/test/cli_matic/presets_test.cljc
@@ -362,7 +362,7 @@
 
 ; YAML
 
-(deftest test-yaml
+(deftest ^:skip-bb test-yaml
   (testing "YAML single value"
     (are [i o]
          (= (parse-cmds-simpler

--- a/test/cli_matic/utils_convert_config_test.cljc
+++ b/test/cli_matic/utils_convert_config_test.cljc
@@ -22,7 +22,7 @@
 ;
 
 
-(deftest unmangle-fn-name-test
+(deftest ^:skip-bb unmangle-fn-name-test
   (are [i o]
        (= o (unmangle-fn-name i))
 
@@ -30,7 +30,7 @@
     "cli_matic.utils_v2$convert_config_v1__GT_v2"
     "cli-matic.utils-v2/convert-config-v1->v2"))
 
-(deftest unmangle-fn-test
+(deftest ^:skip-bb unmangle-fn-test
   (are [i o]
        (= o (unmangle-fn i))
 


### PR DESCRIPTION
This PR makes cli-matic compatible with babashka. Fixes #113.

Changes:

- Use `java.time` instead of `SimpleDateFormat` to parse a date.
- Add bb.edn for running tests with babashka + cognitect test runner (also in CI).
- To check availability of core.async, test using `(require 'clojure.core.async.impl.channels)`: this specific namespace isn't exposed in bb so you cannot use it in this library for bb, but it should still work for JVM Clojure. It seems this impl namespace is only necessary for checking if something is a channel. I wonder if core.async could support that use case better.
- Tests that didn't work with bb (yet) were marked with `^:skip-bb`.
- Upgrade YAML library to fix failing lein tests (unrelated to babashka).