### PR TITLE
Fix warnming in dependency use

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,5 +3,5 @@
  org.clojure/spec.alpha {:mvn/version "0.1.143"}
  org.clojure/tools.cli {:mvn/version "0.3.7"}
  org.clojure/core.async {:mvn/version "0.5.527"}
- expound {:mvn/version "0.7.1"}}}
+ expound/expound {:mvn/version "0.7.1"}}}
 


### PR DESCRIPTION
DEPRECATED: Libs must be qualified, change expound => expound/expound (/home/ieugen/.gitlibs/libs/io.github.l3nz/cli-matic/9cd53ba7336363e3d06650dbad413b6f8b06e471/deps.edn)