### PR TITLE
[#153] Multiple + default progress

### DIFF
--- a/src/cli_matic/utils.cljc
+++ b/src/cli_matic/utils.cljc
@@ -191,7 +191,7 @@
                  opts-2)]
     (apply
      conj positional-opts
-     (flatten (seq opts-3)))))
+     (apply concat (seq opts-3)))))
 
 (s/fdef mk-cli-option
   :args (s/cat :opts ::S/climatic-option)

--- a/test/cli_matic/presets_test.cljc
+++ b/test/cli_matic/presets_test.cljc
@@ -6,7 +6,9 @@
             [cljc.java-time.zoned-date-time :as zoned-date-time]
             [cli-matic.core :refer [parse-command-line]]
             [cli-matic.utils-v2 :refer [convert-config-v1->v2]]
-            [cli-matic.presets :refer [set-help-values set-find-value set-find-didyoumean]]))
+            [cli-matic.presets :refer [set-help-values set-find-value set-find-didyoumean]]
+            [cli-matic.utils :as U]
+            [cli-matic.utils-v2 :as U2]))
 
 (defn cmd_foo [v]
   (prn "Foo:" v)
@@ -240,7 +242,28 @@
       {:commandline  {:_arguments []
                       :val        "defg"}
        :error-text   ""
+       :parse-errors :NONE}))
+  
+  (testing "multiple strings with default"
+    (are [i o]
+         (= (parse-cmds-simpler
+             i
+             (mkDummyCfg {:option "val" :as "x" :type :string :multiple true
+                          :default ["a" "b" "c"]})) o)
+
+         ;
+      ["foo"]
+      {:commandline  {:_arguments []
+                      :val        ["a" "b" "c"]}
+       :error-text   ""
+       :parse-errors :NONE}
+
+      ["foo" "--val" "abcd" "--val" "defg"]
+      {:commandline  {:_arguments []
+                      :val        ["abcd" "defg"]}
+       :error-text   ""
        :parse-errors :NONE})))
+
 
 ; :yyyy-mm-dd
 


### PR DESCRIPTION
* Replaced flatten with apply concat
* Does not actually work - default values are always included
* Specifying values on cli should replace the defaults

```
FAIL in (test-string) (presets_test.cljc:248)
multiple strings with default
expected: (= (parse-cmds-simpler ["foo" "--val" "abcd" "--val" "defg"] (mkDummyCfg {:option "val", :as "x", :type :string, :multiple true, :default ["a" "b" "c"]})) {:commandline {:_arguments [], :val ["abcd" "defg"]}, :error-text "", :parse-errors :NONE})
  actual: (not (= {:commandline {:val ["a" "b" "c" "abcd" "defg"], :_arguments []}, :parse-errors :NONE, :error-text ""} {:commandline {:_arguments [], :val ["abcd" "defg"]}, :error-text "", :parse-errors :NONE}))
```