### PR TITLE
Check for IDeref, not IPending in isJvmPromise?

### DIFF
--- a/src/cli_matic/platform.clj
+++ b/src/cli_matic/platform.clj
@@ -11,7 +11,7 @@
   "
   (:require [clojure.edn :as edn]
             [cli-matic.optionals :as OPT])
-  (:import (clojure.lang IPending)))
+  (:import (clojure.lang IDeref)))
 
 (defn read-env
   "Reads an environment variable.
@@ -82,7 +82,7 @@
 (defn- isJvmPromise?
   "Checks whether the value is a JVM promise."
   [x]
-  (instance? IPending x))
+  (instance? IDeref x))
 
 (defn isDeferredValue?
   "Is this a deferred value for this platform?"

--- a/test/cli_matic/core_test.cljc
+++ b/test/cli_matic/core_test.cljc
@@ -709,5 +709,12 @@
                             :type    :int}]
              :runs        cmd_foo}]))
 
-
-
+(deftest ipending-is-not-ideref-test
+  (let [cmd (fn [& _] (lazy-seq (cons 1 ())))
+        setup {:command     "ipending-example"
+               :opts        []
+               :subcommands [{:command "foo"
+                              :opts    []
+                              :runs    cmd}]}]
+    (is (= (->RV 0 :OK nil [] [])
+           (run-cmd* setup ["foo"])))))


### PR DESCRIPTION
`IPending` is not the way to check if a value can be dereferenced. It is an interface for the function `isRealized`, which is used to check if a given potentially-lazy sequence has been "realized" aka exhausted and fully consumed.

The desired interface is `IDeref`, which is checked in `clojure.core/deref` and which all of the deref'able data structures (atom, delay, etc) implement. (Futures can be deref'd because of the additional check in `clojure.core/deref`.)

Closes #161.